### PR TITLE
Fix the same device issue

### DIFF
--- a/climatenet/utils/losses.py
+++ b/climatenet/utils/losses.py
@@ -18,7 +18,8 @@ def jaccard_loss(logits, true, eps=1e-7):
         jacc_loss: the Jaccard loss.
     """
     num_classes = logits.shape[1]
-    true_1_hot = torch.eye(num_classes)[true.squeeze(1)]
+    # Keep on same device
+    true_1_hot = torch.eye(num_classes).to(true.device)[true.squeeze(1)]
     true_1_hot = true_1_hot.permute(0, 3, 1, 2).float()
     probas = F.softmax(logits, dim=1)
     true_1_hot = true_1_hot.type(logits.type())


### PR DESCRIPTION
Hi Authors,

I fixed this issue RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu) in file `utils/losses.py`. 
Please review it and merge it.

Stacktrace:
```
Epoch 1:
^M  0%|          | 0/396 [00:00<?, ?it/s]^M  0%|          | 0/396 [00:29<?, ?it/s]
Traceback (most recent call last):
  File "/project/60025/anshita/ClimateNet/example.py", line 20, in <module>
    cgnet.train(train)
  File "/project/60025/anshita/ClimateNet/climatenet/models.py", line 90, in train
    loss = jaccard_loss(outputs, labels)
  File "/project/60025/anshita/ClimateNet/climatenet/utils/losses.py", line 21, in jaccard_loss
    true_1_hot = torch.eye(num_classes)[true.squeeze(1)]
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

Thank You.

Best regards,
Anshita Saxena